### PR TITLE
Remove mkmf.log

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -27,6 +27,7 @@ build_extconf = lambda do |fn|
   end
 
   create_header fn
+  rm_f 'mkmf.log'
 end
 
 MRuby::Gem::Specification.new('mruby-file-stat') do |spec|


### PR DESCRIPTION
I use mruby as git submodule and the repository becomes dirty after compilation with mruby-file-stat because it creates mkmf.log.

While I'm not sure what's the best way to clean up mkmf.log, I just share you what I want to do.