### PR TITLE
fix build issue when the source directory is shared between multiple OSs

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -16,7 +16,7 @@ MRuby::Gem::Specification.new('mruby-file-stat') do |spec|
     Dir.chdir build_dir do
       if ENV['OS'] == 'Windows_NT'
         _pp 'on Windows', dir
-        FileUtils.touch "#{dir}/config.h", :verbose => true
+        FileUtils.touch "#{build_dir}/config.h", :verbose => true
       else
         _pp './configure', dir
         system env, "#{dir}/configure"

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,25 +9,21 @@ MRuby::Gem::Specification.new('mruby-file-stat') do |spec|
     'LD' => "#{build.linker.command} #{build.linker.flags.join(' ')}",
     'AR' => build.archiver.command
   }
-  config = "#{dir}/config.h"
-  build_config = "#{build_dir}/config.h"
+  config = "#{build_dir}/config.h"
 
   file config do
-    Dir.chdir dir do
+    FileUtils.mkdir_p build_dir, :verbose => true
+    Dir.chdir build_dir do
       if ENV['OS'] == 'Windows_NT'
         _pp 'on Windows', dir
-        FileUtils.touch "config.h", :verbose => true
+        FileUtils.touch "#{dir}/config.h", :verbose => true
       else
         _pp './configure', dir
-        system env, "./configure"
+        system env, "#{dir}/configure"
       end
     end
   end
-  file build_config => config do
-    FileUtils.mkdir_p build_dir, :verbose => true
-    FileUtils.cp config, build_config, :verbose => true
-  end
-  file "#{dir}/src/file-stat.c" => build_config
+  file "#{dir}/src/file-stat.c" => config
   task :clean do
     FileUtils.rm_f config, :verbose => true
   end


### PR DESCRIPTION
This PR generates config.h in the build directory, so that every build can have its own version of config.h.

Under the current approach, config.h is built under the source directory, only when config.h does not exist or is older than config.h.in.

Therefore, if the source directory is shared among multiple operating systems (e.g. macOS and linux), the first OS that touches the directory builds config.h, and the other OS reuses the existing file.

This leads to a build error if the first OS is macOS and the second is linux, since birthtime_spec is only available in the former.