### PR TITLE
Use locale for path

### DIFF
--- a/src/file-stat.c
+++ b/src/file-stat.c
@@ -10,6 +10,7 @@
 
 #include "config.h"
 
+#include <stdlib.h>
 #ifdef HAVE_SYS_SYSMACROS_H
 #include <sys/sysmacros.h>
 #endif
@@ -165,8 +166,16 @@ file_s_lstat(mrb_state *mrb, mrb_value klass)
     tmp = mrb_convert_type(mrb, fname, MRB_TT_STRING, "String", "to_str");
   }
   path = mrb_str_to_cstr(mrb, tmp);
-  if (LSTAT(path, &st) == -1) {
-    mrb_sys_fail(mrb, path);
+  {
+    char *locale_path;
+    int lstat_result;
+
+    locale_path = mrb_locale_from_utf8(path, -1);
+    lstat_result = LSTAT(locale_path, &st);
+    mrb_locale_free(locale_path);
+    if (lstat_result == -1) {
+      mrb_sys_fail(mrb, path);
+    }
   }
 
   file_class = mrb_class_ptr(klass);
@@ -191,8 +200,16 @@ stat_initialize(mrb_state *mrb, mrb_value self)
     tmp = mrb_convert_type(mrb, fname, MRB_TT_STRING, "String", "to_str");
   }
   path = mrb_str_to_cstr(mrb, tmp);
-  if (STAT(path, &st) == -1) {
-    mrb_sys_fail(mrb, path);
+  {
+    char *locale_path;
+    int stat_result;
+
+    locale_path = mrb_locale_from_utf8(path, -1);
+    stat_result = STAT(locale_path, &st);
+    mrb_locale_free(locale_path);
+    if (stat_result == -1) {
+      mrb_sys_fail(mrb, path);
+    }
   }
 
   ptr = (struct stat *)DATA_PTR(self);


### PR DESCRIPTION
Because the recent mruby accepts UTF-8 string as path and converts the
UTF-8 string to locale string internally. This change uses the same
logic.

See also: https://github.com/mruby/mruby/blob/fb9358206e29c8b018b3b8553e96bf35eb9a4a63/mrbgems/mruby-io/src/io.c#L758