### PR TITLE
Pass --host if build.host_target is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: c
 compiler:
   - gcc
   - clang
+matrix:
+  - compiler: gcc
+  - compiler: clang
+  - env: TARGET=windows-x86_64
 before_install:
   - sudo apt-get -qq update
 install:
@@ -12,4 +16,10 @@ before_script:
   - cd mruby
   - cp -fp ../mruby-file-stat/.travis_build_config.rb build_config.rb
 script:
-  - ruby minirake all test
+  - |-
+    if [[ $TARGET == "windows-x86_64" ]]; then
+      docker run -it -v "$(cd ..; pwd):/root" -w "/root/mruby" \
+        --env TARGET hone/mruby-cli rake all
+    else
+      ruby minirake all test
+    fi

--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -1,7 +1,33 @@
+def gem_config(conf)
+  conf.gembox 'default'
+  conf.gem '../mruby-file-stat'
+end
+
 MRuby::Build.new do |conf|
   toolchain :gcc
-  conf.gembox 'default'
   conf.enable_test
 
-  conf.gem '../mruby-file-stat'
+  gem_config(conf)
+end
+
+if ENV['TARGET'] == 'windows-x86_64'
+  MRuby::CrossBuild.new('windows-x86_64') do |conf|
+    toolchain :gcc
+
+    conf.cc.command       = 'x86_64-w64-mingw32-gcc'
+    conf.linker.command   = 'x86_64-w64-mingw32-gcc'
+    conf.cxx.command      = 'x86_64-w64-mingw32-g++'
+    conf.archiver.command = 'x86_64-w64-mingw32-gcc-ar'
+
+    conf.exts do |exts|
+      exts.object = '.obj'
+      exts.executable = '.exe'
+      exts.library = '.lib'
+    end
+
+    conf.build_target     = 'x86_64-pc-linux-gnu'
+    conf.host_target      = 'x86_64-w64-mingw32'
+
+    gem_config(conf)
+  end
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -19,11 +19,7 @@ MRuby::Gem::Specification.new('mruby-file-stat') do |spec|
         FileUtils.touch "#{build_dir}/config.h", :verbose => true
       else
         _pp './configure', dir
-        host = ''
-        if build.kind_of?(MRuby::CrossBuild) && build.host_target
-          host = "--host #{build.host_target}"
-        end
-        system env, "#{dir}/configure #{host}"
+        system env, "#{dir}/configure"
       end
     end
   end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -19,7 +19,11 @@ MRuby::Gem::Specification.new('mruby-file-stat') do |spec|
         FileUtils.touch "#{build_dir}/config.h", :verbose => true
       else
         _pp './configure', dir
-        system env, "#{dir}/configure"
+        host = ''
+        if build.kind_of?(MRuby::CrossBuild) && build.host_target
+          host = "--host #{build.host_target}"
+        end
+        system env, "#{dir}/configure #{host}"
       end
     end
   end


### PR DESCRIPTION
I needed this for cross-compiling mruby-file-stat on mruby-cli container.