### PR TITLE
Support mruby v3

### DIFF
--- a/.ci_build_config.rb
+++ b/.ci_build_config.rb
@@ -6,6 +6,9 @@ end
 MRuby::Build.new do |conf|
   toolchain :gcc
   conf.enable_test
+  if ENV['DISABLE_PRESYM'] == 'true'
+    conf.disable_presym
+  end
 
   gem_config(conf)
 end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
         mruby-version:
           - 2.1.2
           - 2.0.1
+        include:
+          - mruby-version: 3.0.0-rc
+            disable-presym: 'true'
+          - mruby-version: 3.0.0-rc
+            disable-presym: 'false'
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -26,6 +31,7 @@ jobs:
           CC: gcc
           CXX: g++
           MRUBY_VERSION: ${{ matrix.mruby-version }}
+          DISABLE_PRESYM: ${{ matrix.disable-presym }}
         run: rake test
 
   ubuntu-1804-clang:
@@ -34,6 +40,11 @@ jobs:
         mruby-version:
           - 2.1.2
           - 2.0.1
+        include:
+          - mruby-version: 3.0.0-rc
+            disable-presym: 'true'
+          - mruby-version: 3.0.0-rc
+            disable-presym: 'false'
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -45,6 +56,7 @@ jobs:
           CC: clang
           CXX: clang++
           MRUBY_VERSION: ${{ matrix.mruby-version }}
+          DISABLE_PRESYM: ${{ matrix.disable-presym }}
         run: rake test
 
   ubuntu-1804-mingw:
@@ -53,6 +65,11 @@ jobs:
         mruby-version:
           - 2.1.2
           - 2.0.1
+        include:
+          - mruby-version: 3.0.0-rc
+            disable-presym: 'true'
+          - mruby-version: 3.0.0-rc
+            disable-presym: 'false'
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -65,6 +82,7 @@ jobs:
         env:
           TARGET: windows-x86_64
           MRUBY_VERSION: ${{ matrix.mruby-version }}
+          DISABLE_PRESYM: ${{ matrix.disable-presym }}
         run: rake test
 
   windows-mingw:
@@ -73,6 +91,11 @@ jobs:
         mruby-version:
           - 2.1.2
           - 2.0.1
+        include:
+          - mruby-version: 3.0.0-rc
+            disable-presym: 'true'
+          - mruby-version: 3.0.0-rc
+            disable-presym: 'false'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -83,4 +106,5 @@ jobs:
         env:
           CFLAGS: -g -O1 -Wall -Wundef
           MRUBY_VERSION: ${{ matrix.mruby-version }}
+          DISABLE_PRESYM: ${{ matrix.disable-presym }}
         run: rake test

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,16 @@
 mruby_version = ENV["MRUBY_VERSION"] || 'master'
 mruby_dir = "mruby-#{mruby_version}"
 
-file mruby_dir do
-  sh "git clone --depth=1 --branch #{mruby_version} git://github.com/mruby/mruby.git"
-  sh "mv mruby #{mruby_dir}"
+file 'mruby-head' do
+  sh "git clone --depth 1 --no-single-branch git://github.com/mruby/mruby.git"
+  sh "mv mruby mruby-head"
+end
+
+file mruby_dir => 'mruby-head' do
+  sh "cp -a mruby-head #{mruby_dir}"
+  cd mruby_dir do
+    sh "git checkout #{mruby_version}"
+  end
 end
 
 file "#{mruby_dir}/ci_build_config.rb" => [mruby_dir, ".ci_build_config.rb"] do

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -27,7 +27,10 @@ MRuby::Gem::Specification.new('mruby-file-stat') do |spec|
       end
     end
   end
+
+  # build hook
   file "#{dir}/src/file-stat.c" => config
+
   task :clean do
     FileUtils.rm_f config, :verbose => true
   end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -27,7 +27,7 @@ MRuby::Gem::Specification.new('mruby-file-stat') do |spec|
       end
     end
   end
-  file "#{build_dir}/src/file-stat#{build.exts.object}" => [ "#{dir}/src/file-stat.c", config ]
+  file "#{dir}/src/file-stat.c" => config
   task :clean do
     FileUtils.rm_f config, :verbose => true
   end


### PR DESCRIPTION
Fix broken build hooks.

mruby-3.0.0-rc implements presym.
It build `.pi` file from `.c` before creating `.o`.
`file "#{build_dir}/src/file-stat#{build.exts.object}"` depends on `.o` file only.

`file "#{dir}/src/file-stat.c"` can support both.
It is also a revert https://github.com/ksss/mruby-file-stat/pull/14 