### PR TITLE
Use Ubuntu 22.04 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  ubuntu-1804-gcc:
+  ubuntu-2204-gcc:
     strategy:
       matrix:
         mruby-version:
@@ -20,7 +20,7 @@ jobs:
             disable-presym: 'true'
           - mruby-version: 3.0.0
             disable-presym: 'false'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1.59.1
@@ -34,7 +34,7 @@ jobs:
           DISABLE_PRESYM: ${{ matrix.disable-presym }}
         run: rake test
 
-  ubuntu-1804-clang:
+  ubuntu-2204-clang:
     strategy:
       matrix:
         mruby-version:
@@ -45,7 +45,7 @@ jobs:
             disable-presym: 'true'
           - mruby-version: 3.0.0
             disable-presym: 'false'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1.59.1
@@ -59,7 +59,7 @@ jobs:
           DISABLE_PRESYM: ${{ matrix.disable-presym }}
         run: rake test
 
-  ubuntu-1804-mingw:
+  ubuntu-2204-mingw:
     strategy:
       matrix:
         mruby-version:
@@ -70,7 +70,7 @@ jobs:
             disable-presym: 'true'
           - mruby-version: 3.0.0
             disable-presym: 'false'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1.59.1


### PR DESCRIPTION
Because Ubuntu 18.04 image was unsupported.
See also: https://github.com/actions/runner-images/issues/6002