### PR TITLE
Use https: instead of git: to clone mruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ mruby_version = ENV["MRUBY_VERSION"] || 'master'
 mruby_dir = "mruby-#{mruby_version}"
 
 file 'mruby-head' do
-  sh "git clone --depth 1 --no-single-branch git://github.com/mruby/mruby.git"
+  sh "git clone --depth 1 --no-single-branch https://github.com/mruby/mruby.git"
   sh "mv mruby mruby-head"
 end
 


### PR DESCRIPTION
GitHub removed git: support.
See also: https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/